### PR TITLE
Filter downloads by mime

### DIFF
--- a/maltrieve.py
+++ b/maltrieve.py
@@ -32,6 +32,7 @@ import requests
 import tempfile
 import sys
 import ConfigParser
+import magic
 
 from threading import Thread
 from Queue import Queue
@@ -98,9 +99,13 @@ def exception_handler(request, exception):
     logging.info("Request for %s failed: %s" % (request, exception))
 
 
-def save_malware(response, directory):
+def save_malware(response, directory, ignore_list):
     url = response.url
     data = response.content
+    mime_type = magic.from_buffer(data, mime=True)
+    if mime_type in ignore_list:
+        logging.info('%s in ignore list for %s', mime_type, url)
+        return
     md5 = hashlib.md5(data).hexdigest()
     logging.info("%s hashes to %s" % (url, md5))
     if not os.path.isdir(directory):
@@ -261,7 +266,12 @@ def main():
     cfg['vxcage'] = args.vxcage or config.has_option('Maltrieve', 'vxcage')
     cfg['cuckoo'] = args.cuckoo or config.has_option('Maltrieve', 'cuckoo')
     cfg['logheaders'] = config.get('Maltrieve', 'logheaders')
-
+    
+    ignore_list = []
+    if config.has_option('Maltrieve', 'mime_block'):
+        ignore_list = config.get('Maltrieve', 'mime_block').split(',')
+        
+    
     malware_urls = set()
     for response in source_lists:
         if hasattr(response, 'status_code') and response.status_code == 200:
@@ -274,7 +284,9 @@ def main():
         for each in malware_downloads:
             if not each or each.status_code != 200:
                 continue
-            md5 = save_malware(each, cfg['dumpdir'])
+            md5 = save_malware(each, cfg['dumpdir'], ignore_list)
+            if not md5:
+                continue
             if 'vxcage' in cfg:
                 upload_vxcage(md5)
             if 'cuckoo' in cfg:


### PR DESCRIPTION
Allows filters in the config file to stop storing files of specific mime types

Use Case:
Maltrieve gets lots of HTML pages that i don't want in my viper instance.

add to maltrieve.cfg

```
mime_block = text/html, text/plain 
```

Anything matching the mime by magic bytes is logged but not stored or processed any further.

```
2014-09-28 11:23:01 140329684920064 text/html in ignore list for http://shwmf.net/efckt/
```
