### PR TITLE
Add support for auto submission to CRITs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ optional arguments:
                         Define file for logging progress
   -x, --vxcage          Dump the files to a VxCage instance
   -v, --viper           Dump the files to a Viper instance
+  -r, --crits           Dump the file and domain to a CRITs instance
   -c, --cuckoo          Enable Cuckoo analysis
   -s, --sort_mime       Sort files by MIME type
 

--- a/maltrieve.cfg
+++ b/maltrieve.cfg
@@ -7,7 +7,10 @@ User-Agent = Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)
 #viper = http://127.0.0.1:8080
 #cuckoo = http://127.0.0.1:8090
 #vxcage = http://127.0.0.1:8080
-
+#crits = http://127.0.0.1:8000
+#crits_user = user
+#crits_key = <api_key>
+#crits_source = maltrieve
 
 # Filter Lists are based on mime type NO SPACE BETWEEN ,
 #black_list = text/html,text/plain

--- a/maltrieve.cfg
+++ b/maltrieve.cfg
@@ -7,8 +7,8 @@ User-Agent = Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)
 #viper = http://127.0.0.1:8080
 #cuckoo = http://127.0.0.1:8090
 #vxcage = http://127.0.0.1:8080
-#crits = http://127.0.0.1:8000
-#crits_user = user
+#crits = https://127.0.0.1
+#crits_user = maltrieve
 #crits_key = <api_key>
 #crits_source = maltrieve
 

--- a/maltrieve.py
+++ b/maltrieve.py
@@ -46,6 +46,8 @@ def upload_crits(response, md5, mime_type):
         headers = {'User-agent': 'Maltrieve'}
         zip_files = ['application/zip', 'application/gzip', 'application/x-7z-compressed']
         rar_files = ['application/x-rar-compressed']
+        inserted_domain = False
+        inserted_sample = False
 
         # submit domain / IP
         # TODO: identify if it is a domain or IP and submit accordingly
@@ -63,6 +65,8 @@ def upload_crits(response, md5, mime_type):
                 domain_response_data = domain_response.json()
                 logging.info("Submitted domain info for %s to Crits, response was %s" % (md5,
                              domain_response_data["message"]))
+                if domain_response_data['return_code'] == 0: 
+                    inserted_domain = True
         except:
             logging.info("Exception caught from Crits when submitting domain")
 
@@ -89,13 +93,14 @@ def upload_crits(response, md5, mime_type):
                 sample_response_data = sample_response.json()
                 logging.info("Submitted sample info for %s to Crits, response was %s" % (md5,
                          sample_response_data["message"]))
+                if sample_response_data['return_code'] == 0:
+                    inserted_sample = True
         except:
             logging.info("Exception caught from Crits when submitting sample")
 
         # Create a relationship for the sample and domain        
         url = "{0}/api/v1/relationships/".format(config.get('Maltrieve', 'crits'))
-        if (domain_response.status_code == requests.codes.ok and 
-            sample_response.status_code == requests.codes.ok):
+        if (inserted_sample and inserted_domain):
             relationship_data = {
                 'api_key': cfg['crits_key'],
                 'username': cfg['crits_user'],

--- a/maltrieve.py
+++ b/maltrieve.py
@@ -121,9 +121,9 @@ def upload_crits(response, md5, mime_type):
                     logging.info("Submitted relationship info for %s to Crits, response was %s" % (md5,
                                  relationship_response_data["message"]))
             except:
-                logging.info("Exception caught from Crits when submitting relationship")
+                logging.info("Relationship submission skipped. \n    Domain was %s\n    Sample response was %s\n    Domain response was %s\n" % (url_tag.netloc, sample_response.status_code, domain_response.status_code))
         else:
-            logging.info("Relationship submission skipped. \n    Domain was %s\n    Sample response was %s\n    Domain response was %s\n" % (url_tag.netloc, sample_response.status_code, domain_response.status_code))
+            logging.info("Skipping adding relationship. CRITs could not process domain or sample.")
 
 
 def upload_vxcage(response, md5):

--- a/maltrieve.py
+++ b/maltrieve.py
@@ -117,7 +117,7 @@ def upload_crits(response, md5, mime_type):
             except:
                 logging.info("Exception caught from Crits when submitting relationship")
         else:
-            logging.info("Relationship submission skipped. \n    Domain message was %s\n    Sample message was %s" % (domain_response_data["message"], sample_response_data["message"])
+            logging.info("Relationship submission skipped. \n    Domain message was %s\n    Sample message was %s" % (domain_response_data["message"], sample_response_data["message"]))
 
 
 def upload_vxcage(response, md5):


### PR DESCRIPTION
This path will allow Maltrieve to submit the sample and domain to a CRITs instance. It will then also create a relationship linking the two elements. 

I have tested this on our setup and it works well with a production level CRITs setup. 