### PR TITLE
Fix argument parsing

### DIFF
--- a/maltrieve.py
+++ b/maltrieve.py
@@ -29,12 +29,13 @@ import re
 import resource
 import sys
 import tempfile
+from urlparse import urlparse
+
 import feedparser
 import grequests
 import magic
 import requests
 from bs4 import BeautifulSoup
-from urlparse import urlparse
 
 
 class config:

--- a/maltrieve.py
+++ b/maltrieve.py
@@ -285,7 +285,7 @@ def main():
     hashes = set()
     past_urls = set()
 
-    args = setup_args(sys.argv)
+    args = setup_args(sys.argv[1:])
     cfg = config(args, 'maltrieve.cfg')
 
     if cfg.proxy:


### PR DESCRIPTION
Implementing a function for argument parsing turned up an error where we tried to parse `sys.argv[0]` (the name of the script as called). This fixes #124.