### PR TITLE
Fix Invalid Header

### DIFF
--- a/maltrieve.py
+++ b/maltrieve.py
@@ -480,7 +480,7 @@ def main():
 
     print "Completed source processing"
 
-    headers['User-Agent'] = cfg.useragent
+    headers['User-Agent'] = cfg.useragent["User-Agent"]
     malware_urls = set()
     for response in source_lists:
         if hasattr(response, 'status_code') and response.status_code == 200:


### PR DESCRIPTION
Fix User-Agent:
 InvalidHeader("Header value {'User-Agent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'} must be of type str or bytes, not <type 'dict'>",))